### PR TITLE
Bugfix1

### DIFF
--- a/rdf_storage_sqlite_mro.c
+++ b/rdf_storage_sqlite_mro.c
@@ -36,6 +36,7 @@ const char *LIBRDF_STORAGE_SQLITE_MRO = "http://purl.mro.name/rdf/sqlite/";
 #include <redland.h>
 #include <rdf_storage.h>
 #include <sqlite3.h>
+#include <stdint.h>
 
 #if DEBUG
 #undef NDEBUG

--- a/rdf_storage_sqlite_mro.h
+++ b/rdf_storage_sqlite_mro.h
@@ -35,6 +35,14 @@
  */
 extern const char *LIBRDF_STORAGE_SQLITE_MRO;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void librdf_init_storage_sqlite_mro(librdf_world *world);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif


### PR DESCRIPTION
Hi,

I was trying to write a new model back-end (using the Firebird database) for Redland (librdf) and I chose your code as a model. However when I tested it, I noticed that the values of URIs and literals did not get saved to the SQLite database. I was using gcc (Debian 4.9.3-1) 4.9.3 as the compiler.

I did some debugging and found that at fault was some code that relied on function parameter evaluation order, which is not defined in the C language. I fixed the issue and pushed the commits to my fork of the librdf.sqlite repository in the bugfix1 branch.

If you think that the fix is OK and have the time you can pull the commits from my fork.

Best regards,
Robert Zavalczki